### PR TITLE
Code Cleanup & Enabling logging module (go-logging)

### DIFF
--- a/cmd/logging.go
+++ b/cmd/logging.go
@@ -62,6 +62,4 @@ func SetupLogger()  {
 	} else {
 		log.Debugf("All %s log messages are logged into: %s", toolName, logFilename)
 	}
-
-	log.Infof(logLevel)
 }

--- a/cmd/logging.go
+++ b/cmd/logging.go
@@ -1,0 +1,67 @@
+/*
+Greenplum Magic Tool
+
+Authored by Tyler Ramer, Ignacio Elizaga
+Copyright 2018
+
+Licensed under the Apache License, Version 2.0 (the "License")
+
+*/
+package cmd
+
+import (
+	"github.com/op/go-logging"
+	"os"
+	"fmt"
+	"time"
+)
+
+// Logger name and logging format
+var (
+	log = logging.MustGetLogger(toolName)
+	format = logging.MustStringFormatter(
+		`%{color}%{time:15:04:05.000} %{shortfile}(%{shortfunc}) ▶ %{level:.4s} ▶ %{color:reset} %{message}`,
+	)
+)
+
+// Setup the logger.
+func SetupLogger()  {
+
+	// Check if the log level os parameter is set, to turn on debug logging
+	var logLevel = os.Getenv("LOG_LEVEL")
+
+	// New On Screen logger
+	backendScreen := logging.NewLogBackend(os.Stderr, "", 0)
+	screenFormatted := logging.NewBackendFormatter(backendScreen, format)
+	screenLevelled := logging.AddModuleLevel(screenFormatted)
+
+	// Setup logfile logger
+	logFilename := fmt.Sprintf("/tmp/gpmt_log_%s", time.Now().Format("2006-01-02"))
+	file, err := os.OpenFile(logFilename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
+	backendFile := logging.NewLogBackend(file, "", 0)
+	fileFormatter := logging.NewBackendFormatter(backendFile, format)
+	fileLeveled := logging.AddModuleLevel(fileFormatter)
+
+	// Setup the logging level based on users request
+	if logLevel == "DEBUG" {
+		screenLevelled.SetLevel(logging.DEBUG, "")
+		fileLeveled.SetLevel(logging.DEBUG, "")
+	} else {
+		screenLevelled.SetLevel(logging.INFO, "")
+		fileLeveled.SetLevel(logging.INFO, "")
+	}
+
+	// Start the logger
+	logging.SetBackend(screenLevelled, fileLeveled)
+
+	// If the file creation failed, then place a warning message on the screen.
+	// NOTE: the reason why place the err catcher here is simply because the logger has not
+	// initialized yet, until we set the backend.
+	if err != nil {
+		log.Warningf("Cannot log onto logfile: %s, ERROR: %v", logFilename, err)
+	} else {
+		log.Debugf("All %s log messages are logged into: %s", toolName, logFilename)
+	}
+
+	log.Infof(logLevel)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,41 +7,37 @@ Copyright 2018
 Licensed under the Apache License, Version 2.0 (the "License")
 
 */
-
-// cobra command line
-
 package cmd
 
 import (
 	"fmt"
 	"os"
 	"github.com/spf13/cobra"
-	log "github.com/Sirupsen/logrus"
 )
 
 // global variables
 var (
-	verbose bool
+	toolName = "gpmt"
 	version = "Version ALPHA 1"
 	LCFlags LogCollectorFlags
+	githubRepo = "https://github.com/pivotal-gss/gpmt2"
 )
 
 // The root CLI.
 var rootCmd = &cobra.Command{
-	Use:   "gpmt",
-	Short: "GPMT - diagnostic and data collection for Greemplum Database",
+	Use:   toolName,
+	Short: "Diagnostic and data collection for Greenplum Database",
 	Long:  "Greenplum Magic Tool is a collection of diagnostic and data collection tools to " +
 		   "assist in troubleshooting issues with Greenplum Database. \n" +
-		   "Documentation and development information is available at: https://github.com/pivotal-gss/gpmt2",
+		   "Documentation and development information is available at: " + githubRepo,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// Before running any command setup the logger
+		SetupLogger()
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// if no argument specified throw the help menu on the screen
 		cmd.Help()
 	},
-}
-
-// The root CLI flags
-func flagsRoot() {
-	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable debug logging")
 }
 
 // Sub Command: Version
@@ -106,7 +102,6 @@ func flagsLogCollector() {
 func init() {
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(logCollectorCmd)
-	flagsRoot()
 	flagsLogCollector()
 }
 
@@ -116,11 +111,4 @@ func Execute() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	if verbose {
-		log.SetLevel(log.DebugLevel)
-	} else {
-		log.SetLevel(log.ErrorLevel)
-	}
-	log.Debug("test")
-	log.Error("test err")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,33 +15,74 @@ package cmd
 import (
 	"fmt"
 	"os"
-
-	log "github.com/Sirupsen/logrus"
-
 	"github.com/spf13/cobra"
+	log "github.com/Sirupsen/logrus"
 )
 
-// global flag variables
-
+// global variables
 var (
 	verbose bool
-)
-
-func init() {
-	rootCmd.AddCommand(versionCmd)
-	rootCmd.AddCommand(logCollectorCmd)
-	flagsRoot()
-	flagsLogCollector()
-}
-
-func flagsRoot() {
-	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Debug level logging recorded in gpmt logs")
-}
-
-var (
+	version = "Version ALPHA 1"
 	LCFlags LogCollectorFlags
 )
 
+// The root CLI.
+var rootCmd = &cobra.Command{
+	Use:   "gpmt",
+	Short: "GPMT - diagnostic and data collection for Greemplum Database",
+	Long:  "Greenplum Magic Tool is a collection of diagnostic and data collection tools to " +
+		   "assist in troubleshooting issues with Greenplum Database. \n" +
+		   "Documentation and development information is available at: https://github.com/pivotal-gss/gpmt2",
+	Run: func(cmd *cobra.Command, args []string) {
+		// if no argument specified throw the help menu on the screen
+		cmd.Help()
+	},
+}
+
+// The root CLI flags
+func flagsRoot() {
+	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable debug logging")
+}
+
+// Sub Command: Version
+// When this command is used the version of the gpmt is displayed on the screen
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "GPDB Version number",
+	Long:  `Greenplum Magic Tool version`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// print the version number on the screen when asked.
+		fmt.Printf("%s: %s \n", cmd.Long, version)
+	},
+}
+
+// Sub Command: Log Collector
+// This command line arguments helps to obtain the logs from the greenplum database
+var logCollectorCmd = &cobra.Command{
+	Use:   "gp_log_collector",
+	Short: "easy log collection",
+	Long:  "gp_log_collector is used to automate Greenplum database log collection. " +
+		   "Run without options, gp_log_collector will gather today's master and standby logs",
+	Run: func(cmd *cobra.Command, args []string) {
+		// log collect
+		fmt.Println("I'll be a log collector one day")
+	},
+}
+
+// -failed-segs only failed segs
+// -free-space threshold
+// -c contents
+// -hostfile
+// -h hostnames
+// -start
+// -end
+// -a no propmt
+// -dir
+// -segdir
+// -skip-master
+// -standby (?)
+
+// All the usage flags of the log collector
 func flagsLogCollector() {
 	logCollectorCmd.Flags().BoolVar(&LCFlags.failedOnly, "failed-segs", false, "Query gp_configuration_history for list of faulted content ids")
 	logCollectorCmd.Flags().IntVar(&LCFlags.freeSpace, "free-space", 10, "default=10  Free space threshold which will abort log collection if reached")
@@ -60,48 +101,16 @@ func flagsLogCollector() {
 	logCollectorCmd.Flags().BoolVar(&LCFlags.standby, "collect-standby", false, "Collect information from the standby master")
 }
 
-// -failed-segs only failed segs
-// -free-space threshold
-// -c contents
-// -hostfile
-// -h hostnames
-// -start
-// -end
-// -a no propmt
-// -dir
-// -segdir
-// -skip-master
 
-// -standby (?)
-
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "GPDB Version number",
-	Long:  `Greenplum Magic Tool version`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Version ALPHA 1")
-	},
+// Initialize the cobra command CLI.
+func init() {
+	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(logCollectorCmd)
+	flagsRoot()
+	flagsLogCollector()
 }
 
-var rootCmd = &cobra.Command{
-	Use:   "gpmt",
-	Short: "GPMT - diagnostic and data collection for Greemplum Database",
-	Long:  "Greenplum Magic Tool is a collection of diagnostic and data collection tools to assist in troubleshooting issues with Greenplum Database. Documentation and development information is available at https://github.com/pivotal-gss/gpmt2",
-	Run: func(cmd *cobra.Command, args []string) {
-		// probably just help
-	},
-}
-
-var logCollectorCmd = &cobra.Command{
-	Use:   "gp_log_collector",
-	Short: "easy log collection",
-	Long:  "gp_log_collector is used to automate Greenplum database log collection. Run without options, gp_log_collector will gather today's master and standby logs",
-	Run: func(cmd *cobra.Command, args []string) {
-		// log collect
-		fmt.Println("I'll be a log collector one day")
-	},
-}
-
+// Execute the cobra CLI
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/gpmt.go
+++ b/gpmt.go
@@ -20,27 +20,12 @@ Copyright 2018
 package main
 
 import (
-	"fmt"
-	log "github.com/Sirupsen/logrus"
 	"github.com/pivotal-gss/gpmt2/cmd"
-	"io"
-	"os"
-	"time"
 )
 
-// TODO: maybe clean this up by adding a logrus file hook
-// https://github.com/Sirupsen/logrus/issues/230
-func init() {
-	logFilename := fmt.Sprintf("/tmp/gpmt_log_%s", time.Now().Format("2006-01-02"))
-	logFile, err := os.OpenFile(logFilename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
-	if err != nil {
-		log.WithField("file", logFilename).Error("could not open file - please please ensure user has write access")
-		log.Error("continuing with stdout only")
-	}
-	mw := io.MultiWriter(os.Stdout, logFile)
-	log.SetOutput(mw)
-}
-
+// the main block
 func main() {
 	cmd.Execute()
 }
+
+

--- a/gpmt.go
+++ b/gpmt.go
@@ -1,9 +1,7 @@
-/*
-Greenplum magic tool
+/* Greenplum magic tool
 
 Authored by Tyler Ramer, Ignacio Elizaga
 Copyright 2018
-
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,19 +15,17 @@ Copyright 2018
    See the License for the specific language governing permissions and
    limitations under the License.
 
-
 */
 
 package main
 
 import (
 	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/pivotal-gss/gpmt2/cmd"
 	"io"
 	"os"
 	"time"
-
-	log "github.com/Sirupsen/logrus"
-	"github.com/pivotal-gss/gpmt2/cmd"
 )
 
 // TODO: maybe clean this up by adding a logrus file hook


### PR DESCRIPTION
+ Add more structure ( or format ) to code
+ cleaned up unnecessary white space
+ added comments for contributors can understand what is the use of the code.
+ removed all global persistent flag since those flags are no use when used with subcommands , this is due to cobras design flow.
+ moved the logger from logrus to go-logging for easier log control and formatting