### PR TITLE
Setting the timestamp format for logger.

### DIFF
--- a/cmd/gpmt/root.go
+++ b/cmd/gpmt/root.go
@@ -71,7 +71,14 @@ var rootCmd = &cobra.Command{
 		} else {
 			log.SetLevel(log.InfoLevel)
 		}
+
+		// Set logger logfile  hooks
 		logName := logOpts.LogDir + logOpts.LogFile
+		formatter := &log.TextFormatter{
+			TimestampFormat : "2006-01-02 15:04:05",
+			FullTimestamp: true,
+		}
+		log.SetFormatter(formatter)
 		log.AddHook(lfshook.NewHook(logName, &log.TextFormatter{}))
 
 	},


### PR DESCRIPTION
The logger earlier didnt print the timestamp of the logging

```
DEBU[0000] Connecting to the database using the connection string: user=faisal password= host=localhost port=5432 dbname=template1 sslmode=disable  uri="user=faisal password= host=localhost port=5432 dbname=template1 sslmode=disable"
```

this change helps to print the timestamp.

```
DEBU[2018-08-20 10:54:52] Connecting to the database using the connection string: user=faisal password= host=localhost port=5432 dbname=template1 sslmode=disable  uri="user=faisal password= host=localhost port=5432 dbname=template1 sslmode=disable"
```