### PR TITLE
A wrapper on os execute function.

### DIFF
--- a/pkg/bash/runBash.go
+++ b/pkg/bash/runBash.go
@@ -68,7 +68,8 @@ func RunBashCmd(timeout int, command string, args ...string) (string, error) {
 	if timeout == 0 {
 		err := <-done
 		if err != nil {
-			return "", err
+			close(done)
+			return "", fmt.Errorf("process done, with error: %s", err.Error())
 		}
 		// Done, send the information back to user
 		return buf.String(), nil

--- a/pkg/bash/runBash.go
+++ b/pkg/bash/runBash.go
@@ -1,0 +1,74 @@
+package bash
+
+import (
+	"fmt"
+	"os/exec"
+	"bytes"
+	"time"
+	log "github.com/sirupsen/logrus"
+)
+
+// Wrapper to execute bash command, this will take in the below arguments.
+// timeout: timeout value in ( sections ) which is the maximum time it waits before terminating the process
+// command: the bash command that it needs to execute
+// args: the arguments the needs to be used along with the command.
+// eg.s RunBashCmd(5, "ping", "-c25", "8.8.8.8")
+// this will return the result of the output and a error if it falls into any
+func RunBashCmd(timeout int, command string, args ...string) (string, error) {
+
+	log.Debugf("Executing the command: %s %v", command, args)
+
+	// instantiate new command
+	cmd := exec.Command(command, args...)
+
+	// get pipe to standard output
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "" , fmt.Errorf("cmd.StdoutPipe() error: %s", err.Error())
+	}
+
+	// start process via command
+	if err := cmd.Start(); err != nil {
+		return "" , fmt.Errorf("cmd.Start() error: %s", err.Error())
+	}
+
+	// Start a ticker to capture the time that it waiting
+	// only good for debugging.
+	ticker := time.NewTicker(time.Second)
+	go func(ticker *time.Ticker) {
+		now := time.Now()
+		for _ = range ticker.C {
+			log.Debugf("Command: %s %v, waiting: %s", command, args, []byte(fmt.Sprintf("%s", time.Since(now))))
+		}
+	}(ticker)
+
+	// setup a buffer to capture standard output
+	var buf bytes.Buffer
+
+	// create a channel to capture any errors from wait
+	done := make(chan error)
+	go func() {
+		if _, err := buf.ReadFrom(stdout); err != nil {
+			log.Panicf("buf.Read(stdout) error: %s", err.Error())
+		}
+		done <- cmd.Wait()
+	}()
+
+	// block on select, and switch based on actions received
+	select {
+		// Terminate the process since the timeout has reached.
+		case <-time.After(time.Duration(timeout) * time.Second):
+			if err := cmd.Process.Kill(); err != nil {
+				return "", fmt.Errorf("failed to kill: %s", err.Error())
+			}
+			return "", fmt.Errorf("timeout reached, process killed")
+		// The command is done, send the output back to the user
+		case err := <-done:
+			if err != nil {
+				close(done)
+				return "", fmt.Errorf("process done, with error: %s", err.Error())
+			}
+			return buf.String(), nil
+	}
+	return "", nil
+}

--- a/pkg/bash/runBash.go
+++ b/pkg/bash/runBash.go
@@ -9,14 +9,18 @@ import (
 )
 
 // Wrapper to execute bash command, this will take in the below arguments.
-// timeout: timeout value in ( sections ) which is the maximum time it waits before terminating the process
+// timeout: timeout value in ( sections ) which is the maximum time it waits before terminating the process ( 0 to disable )
 // command: the bash command that it needs to execute
 // args: the arguments the needs to be used along with the command.
 // eg.s RunBashCmd(5, "ping", "-c25", "8.8.8.8")
 // this will return the result of the output and a error if it falls into any
 func RunBashCmd(timeout int, command string, args ...string) (string, error) {
 
-	log.Debugf("Executing the command: %s %v", command, args)
+	// Check if the command executable exists
+	_, err :=  exec.LookPath(command)
+	if err != nil {
+		return "", err
+	}
 
 	// instantiate new command
 	cmd := exec.Command(command, args...)
@@ -32,13 +36,19 @@ func RunBashCmd(timeout int, command string, args ...string) (string, error) {
 		return "" , fmt.Errorf("cmd.Start() error: %s", err.Error())
 	}
 
+	// now we have the command started
+	// the process number for this process is
+	process := cmd.Process
+	pid := process.Pid
+	log.Debugf("Executing the command: %s %v, Process: %d", command, args, pid)
+
 	// Start a ticker to capture the time that it waiting
 	// only good for debugging.
 	ticker := time.NewTicker(time.Second)
 	go func(ticker *time.Ticker) {
 		now := time.Now()
 		for _ = range ticker.C {
-			log.Debugf("Command: %s %v, waiting: %s", command, args, []byte(fmt.Sprintf("%s", time.Since(now))))
+			log.Debugf("Waiting on process (%d): %s", pid, []byte(fmt.Sprintf("%s", time.Since(now))))
 		}
 	}(ticker)
 
@@ -54,11 +64,20 @@ func RunBashCmd(timeout int, command string, args ...string) (string, error) {
 		done <- cmd.Wait()
 	}()
 
-	// block on select, and switch based on actions received
-	select {
+	// If timeout is disabled then wait for the command to finish.
+	if timeout == 0 {
+		err := <-done
+		if err != nil {
+			return "", err
+		}
+		// Done, send the information back to user
+		return buf.String(), nil
+	} else {
+		// block on select, and switch based on actions received
+		select {
 		// Terminate the process since the timeout has reached.
 		case <-time.After(time.Duration(timeout) * time.Second):
-			if err := cmd.Process.Kill(); err != nil {
+			if err := process.Kill(); err != nil {
 				return "", fmt.Errorf("failed to kill: %s", err.Error())
 			}
 			return "", fmt.Errorf("timeout reached, process killed")
@@ -69,6 +88,9 @@ func RunBashCmd(timeout int, command string, args ...string) (string, error) {
 				return "", fmt.Errorf("process done, with error: %s", err.Error())
 			}
 			return buf.String(), nil
+		}
 	}
+
+	// Should never reach here.
 	return "", nil
 }

--- a/pkg/bash/runBash.go
+++ b/pkg/bash/runBash.go
@@ -48,7 +48,7 @@ func RunBashCmd(timeout int, command string, args ...string) (string, error) {
 	go func(ticker *time.Ticker) {
 		now := time.Now()
 		for _ = range ticker.C {
-			log.Debugf("Waiting on process (%d): %s", pid, []byte(fmt.Sprintf("%s", time.Since(now))))
+			log.Debugf("Waiting on process(%d): %s", pid, []byte(fmt.Sprintf("%s", time.Since(now))))
 		}
 	}(ticker)
 
@@ -69,7 +69,7 @@ func RunBashCmd(timeout int, command string, args ...string) (string, error) {
 		err := <-done
 		if err != nil {
 			close(done)
-			return "", fmt.Errorf("process done, with error: %s", err.Error())
+			return "", fmt.Errorf("process(%d) done, with error: %s", pid, err.Error())
 		}
 		// Done, send the information back to user
 		return buf.String(), nil
@@ -79,14 +79,14 @@ func RunBashCmd(timeout int, command string, args ...string) (string, error) {
 		// Terminate the process since the timeout has reached.
 		case <-time.After(time.Duration(timeout) * time.Second):
 			if err := process.Kill(); err != nil {
-				return "", fmt.Errorf("failed to kill: %s", err.Error())
+				return "", fmt.Errorf("failed to kill the process(%d): %s", pid, err.Error())
 			}
-			return "", fmt.Errorf("timeout reached, process killed")
+			return "", fmt.Errorf("timeout reached, process(%d) killed", pid)
 		// The command is done, send the output back to the user
 		case err := <-done:
 			if err != nil {
 				close(done)
-				return "", fmt.Errorf("process done, with error: %s", err.Error())
+				return "",fmt.Errorf("process(%d) done, with error: %s", pid, err.Error())
 			}
 			return buf.String(), nil
 		}


### PR DESCRIPTION
+ A wrapper on os/exec library.
+ The feature include a timeout which can set to kill any long running processes.
+ Right now, this return a string in the output, but we can change it based on the needs, my current prediction or understanding is we only need this to execute OS command not to receive output like "ls-ltr", this can be worked on later based on requirements